### PR TITLE
Add Flatpak extension installation support

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -13,7 +13,7 @@ portal_sources = files(
   'org.freedesktop.portal.DynamicLauncher.xml',
   'org.freedesktop.portal.Email.xml',
   'org.freedesktop.portal.FileChooser.xml',
-  'org.freedesktop.portal.Flatpak.xml',
+  'org.freedesktop.portal.FlatpakInstaller.xml',
   'org.freedesktop.portal.FileTransfer.xml',
   'org.freedesktop.portal.GameMode.xml',
   'org.freedesktop.portal.GlobalShortcuts.xml',

--- a/data/meson.build
+++ b/data/meson.build
@@ -13,6 +13,7 @@ portal_sources = files(
   'org.freedesktop.portal.DynamicLauncher.xml',
   'org.freedesktop.portal.Email.xml',
   'org.freedesktop.portal.FileChooser.xml',
+  'org.freedesktop.portal.Flatpak.xml',
   'org.freedesktop.portal.FileTransfer.xml',
   'org.freedesktop.portal.GameMode.xml',
   'org.freedesktop.portal.GlobalShortcuts.xml',

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<!--
+ Copyright (C) 2024 Red Hat, Inc.
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Flatpak:
+      @short_description: Flatpak portal
+
+      This interface lets sandboxed applications interact with the
+      Flatpak system on the host.
+
+      This documentation describes version 1 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.Flatpak">
+    <!--
+        InstallExtensions:
+        @extensions: List of extension IDs to install
+        @options: Vardict with optional further information
+        @handle: Object path for the :ref:`org.freedesktop.portal.Flatpak.InstallMonitor` object
+
+        Requests the installation of one or more extensions for the calling
+        application. The extension IDs must start with the application ID
+        of the caller.
+
+        Supported keys in the @options vardict include:
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle.
+          Must be a valid object path element.
+    -->
+    <method name="InstallExtensions">
+      <arg type="as" name="extensions" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+
+  <!--
+      org.freedesktop.portal.Flatpak.InstallMonitor:
+      @short_description: Monitor for extension installation
+
+      This interface is used to monitor the progress of an extension
+      installation requested via :ref:`org.freedesktop.portal.Flatpak.InstallExtensions`.
+  -->
+  <interface name="org.freedesktop.portal.Flatpak.InstallMonitor">
+    <!--
+        Close:
+
+        Ends the installation and closes the monitor.
+    -->
+    <method name="Close"/>
+
+    <!--
+        Progress:
+        @info: Vardict with progress information
+
+        Emitted to indicate the progress of the installation.
+
+        Supported keys in the @info vardict include:
+
+        * ``status`` (``u``)
+
+          The overall status of the installation.
+          0: Running
+          1: Done
+          2: Failed
+
+        * ``progress`` (``u``)
+
+          The progress of the current operation, as a number between 0 and 100.
+
+        * ``error`` (``s``)
+
+          The error name, sent when status is Failed.
+
+        * ``error_message`` (``s``)
+
+          The error message, sent when status is Failed.
+    -->
+    <signal name="Progress">
+      <arg type="a{sv}" name="info" direction="out"/>
+    </signal>
+  </interface>
+</node>

--- a/data/org.freedesktop.portal.FlatpakInstaller.xml
+++ b/data/org.freedesktop.portal.FlatpakInstaller.xml
@@ -24,7 +24,7 @@
       @short_description: Flatpak installer portal
 
       This interface lets sandboxed applications interact with the
-      Flatpak system on the host to install extensions.
+      Flatpak system on the host to install, uninstall, and update extensions.
 
       This documentation describes version 1 of this interface.
   -->
@@ -50,6 +50,83 @@
       <arg type="as" name="extensions" direction="in"/>
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        UninstallExtensions:
+        @extensions: List of extension IDs to uninstall
+        @options: Vardict with optional further information
+        @handle: Object path for the :ref:`org.freedesktop.portal.FlatpakInstaller.InstallMonitor` object
+
+        Requests the uninstallation of one or more extensions for the calling
+        application. The extension IDs must start with the application ID
+        of the caller.
+
+        Supported keys in the @options vardict include:
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle.
+          Must be a valid object path element.
+    -->
+    <method name="UninstallExtensions">
+      <arg type="as" name="extensions" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        UpdateExtensions:
+        @extensions: List of extension IDs to update
+        @options: Vardict with optional further information
+        @handle: Object path for the :ref:`org.freedesktop.portal.FlatpakInstaller.InstallMonitor` object
+
+        Requests the update of one or more extensions for the calling
+        application. The extension IDs must start with the application ID
+        of the caller.
+
+        Supported keys in the @options vardict include:
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle.
+          Must be a valid object path element.
+    -->
+    <method name="UpdateExtensions">
+      <arg type="as" name="extensions" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+        ListExtensions:
+        @options: Vardict with optional further information
+        @extensions: List of installed extensions with basic info
+
+        Returns a list of installed extensions for the calling application.
+        The extension IDs will start with the application ID of the caller.
+
+        The @extensions array consists of vardicts with the following keys:
+
+        * ``id`` (``s``)
+
+          The extension ID.
+
+        * ``name`` (``s``)
+
+          The name of the extension.
+
+        * ``version`` (``s``)
+
+          The version of the extension.
+
+        * ``summary`` (``s``)
+
+          A brief summary of the extension.
+    -->
+    <method name="ListExtensions">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="aa{sv}" name="extensions" direction="out"/>
     </method>
 
     <property name="version" type="u" access="read"/>

--- a/data/org.freedesktop.portal.FlatpakInstaller.xml
+++ b/data/org.freedesktop.portal.FlatpakInstaller.xml
@@ -20,20 +20,20 @@
 
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <!--
-      org.freedesktop.portal.Flatpak:
-      @short_description: Flatpak portal
+      org.freedesktop.portal.FlatpakInstaller:
+      @short_description: Flatpak installer portal
 
       This interface lets sandboxed applications interact with the
-      Flatpak system on the host.
+      Flatpak system on the host to install extensions.
 
       This documentation describes version 1 of this interface.
   -->
-  <interface name="org.freedesktop.portal.Flatpak">
+  <interface name="org.freedesktop.portal.FlatpakInstaller">
     <!--
         InstallExtensions:
         @extensions: List of extension IDs to install
         @options: Vardict with optional further information
-        @handle: Object path for the :ref:`org.freedesktop.portal.Flatpak.InstallMonitor` object
+        @handle: Object path for the :ref:`org.freedesktop.portal.FlatpakInstaller.InstallMonitor` object
 
         Requests the installation of one or more extensions for the calling
         application. The extension IDs must start with the application ID
@@ -56,13 +56,13 @@
   </interface>
 
   <!--
-      org.freedesktop.portal.Flatpak.InstallMonitor:
+      org.freedesktop.portal.FlatpakInstaller.InstallMonitor:
       @short_description: Monitor for extension installation
 
       This interface is used to monitor the progress of an extension
-      installation requested via :ref:`org.freedesktop.portal.Flatpak.InstallExtensions`.
+      installation requested via :ref:`org.freedesktop.portal.FlatpakInstaller.InstallExtensions`.
   -->
-  <interface name="org.freedesktop.portal.Flatpak.InstallMonitor">
+  <interface name="org.freedesktop.portal.FlatpakInstaller.InstallMonitor">
     <!--
         Close:
 

--- a/doc/api-reference.rst
+++ b/doc/api-reference.rst
@@ -44,6 +44,8 @@ All apps have access to the portals below:
    doc-org.freedesktop.portal.Email.rst
    doc-org.freedesktop.portal.FileChooser.rst
    doc-org.freedesktop.portal.FileTransfer.rst
+   doc-org.freedesktop.portal.FlatpakInstaller.rst
+   doc-org.freedesktop.portal.FlatpakInstaller.InstallMonitor.rst
    doc-org.freedesktop.portal.GameMode.rst
    doc-org.freedesktop.portal.GlobalShortcuts.rst
    doc-org.freedesktop.portal.Inhibit.rst

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,6 +2,7 @@
 src/background.c
 src/camera.c
 src/dynamic-launcher.c
+src/flatpak.c
 src/location.c
 src/screenshot.c
 src/settings.c

--- a/src/flatpak.c
+++ b/src/flatpak.c
@@ -24,6 +24,7 @@
 
 #include <gio/gio.h>
 #include <glib/gi18n.h>
+#include <string.h>
 
 #include "xdp-app-info.h"
 #include "xdp-context.h"
@@ -38,6 +39,7 @@ typedef struct _FlatpakPortalClass FlatpakPortalClass;
 struct _FlatpakPortal
 {
   XdpDbusFlatpakInstallerSkeleton parent_instance;
+  XdpContext *context;
 };
 
 struct _FlatpakPortalClass
@@ -53,6 +55,7 @@ struct _InstallMonitor
   XdpDbusFlatpakInstallerInstallMonitorSkeleton parent_instance;
   XdpContext *context;
   char *id;
+  char *sender;
   GCancellable *cancellable;
 };
 
@@ -84,6 +87,20 @@ install_monitor_init (InstallMonitor *monitor)
 }
 
 static void
+install_monitor_close (InstallMonitor *monitor)
+{
+  if (!g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (monitor)))
+    return;
+
+  g_debug ("Closing install monitor %s", monitor->id);
+
+  g_cancellable_cancel (monitor->cancellable);
+
+  xdp_context_unclaim_object_path (monitor->context, monitor->id);
+  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (monitor));
+}
+
+static void
 install_monitor_finalize (GObject *object)
 {
   InstallMonitor *monitor = (InstallMonitor *)object;
@@ -91,6 +108,7 @@ install_monitor_finalize (GObject *object)
   g_cancellable_cancel (monitor->cancellable);
   g_clear_object (&monitor->cancellable);
   g_free (monitor->id);
+  g_free (monitor->sender);
 
   G_OBJECT_CLASS (install_monitor_parent_class)->finalize (object);
 }
@@ -109,11 +127,7 @@ handle_close (XdpDbusFlatpakInstallerInstallMonitor *object,
 {
   InstallMonitor *monitor = (InstallMonitor *)object;
 
-  g_debug ("Closing install monitor %s", monitor->id);
-
-  g_cancellable_cancel (monitor->cancellable);
-  xdp_context_unclaim_object_path (monitor->context, monitor->id);
-  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (monitor));
+  install_monitor_close (monitor);
 
   xdp_dbus_flatpak_installer_install_monitor_complete_close (object, invocation);
 
@@ -126,15 +140,36 @@ install_monitor_iface_init (XdpDbusFlatpakInstallerInstallMonitorIface *iface)
   iface->handle_close = handle_close;
 }
 
+static void
+on_peer_disconnect (XdpContext *context,
+                    const char *name,
+                    gpointer    user_data)
+{
+  InstallMonitor *monitor = user_data;
+
+  if (g_strcmp0 (monitor->sender, name) == 0)
+    {
+      g_debug ("Peer %s disconnected, closing monitor %s", name, monitor->id);
+      install_monitor_close (monitor);
+    }
+}
+
 static InstallMonitor *
 install_monitor_new (XdpContext *context,
-                     const char *id)
+                     const char *id,
+                     const char *sender)
 {
   InstallMonitor *monitor;
 
   monitor = g_object_new (install_monitor_get_type (), NULL);
   monitor->context = context;
   monitor->id = g_strdup (id);
+  monitor->sender = g_strdup (sender);
+
+  g_signal_connect_object (context, "peer-disconnect",
+                           G_CALLBACK (on_peer_disconnect),
+                           monitor,
+                           G_CONNECT_DEFAULT);
 
   return monitor;
 }
@@ -146,8 +181,16 @@ flatpak_portal_init (FlatpakPortal *portal)
 }
 
 static void
+flatpak_portal_finalize (GObject *object)
+{
+  G_OBJECT_CLASS (flatpak_portal_parent_class)->finalize (object);
+}
+
+static void
 flatpak_portal_class_init (FlatpakPortalClass *klass)
 {
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->finalize = flatpak_portal_finalize;
 }
 
 static void
@@ -158,6 +201,10 @@ emit_progress (InstallMonitor *monitor,
                const char     *error_message)
 {
   GVariantBuilder builder;
+
+  if (!g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (monitor)))
+    return;
+
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (&builder, "{sv}", "status", g_variant_new_uint32 (status));
   g_variant_builder_add (&builder, "{sv}", "progress", g_variant_new_uint32 (progress));
@@ -166,14 +213,14 @@ emit_progress (InstallMonitor *monitor,
   if (error_message)
     g_variant_builder_add (&builder, "{sv}", "error_message", g_variant_new_string (error_message));
 
-  xdp_dbus_flatpak_installer_install_monitor_emit_progress (XDP_DBUS_FLATPAK_INSTALLER_INSTALL_MONITOR (monitor),
+  xdp_dbus_flatpak_installer_install_monitor_emit_progress (XDP_DBUS_FLATPAK_INSTALL_MONITOR (monitor),
                                                   g_variant_builder_end (&builder));
 }
 
 static void
-install_finished_cb (GObject      *source,
-                     GAsyncResult *result,
-                     gpointer      user_data)
+operation_finished_cb (GObject      *source,
+                       GAsyncResult *result,
+                       gpointer      user_data)
 {
   g_autoptr(InstallMonitor) monitor = user_data;
   g_autoptr(GError) error = NULL;
@@ -183,42 +230,23 @@ install_finished_cb (GObject      *source,
       if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
         return;
 
-      g_warning ("Flatpak install failed: %s", error->message);
+      g_warning ("Flatpak operation failed: %s", error->message);
       emit_progress (monitor, 2, 0, "org.freedesktop.portal.FlatpakInstaller.Error.Failed", error->message);
     }
   else
     {
-      g_debug ("Flatpak install finished successfully");
+      g_debug ("Flatpak operation finished successfully");
       emit_progress (monitor, 1, 100, NULL, NULL);
     }
 }
 
 static gboolean
-handle_install_extensions (XdpDbusFlatpakInstaller        *object,
-                           GDBusMethodInvocation *invocation,
-                           const char * const    *arg_extensions,
-                           GVariant              *arg_options)
+validate_extensions (GDBusMethodInvocation *invocation,
+                     const char * app_id,
+                     const char * const * arg_extensions)
 {
-  XdpContext *context = g_object_get_data (G_OBJECT (object), "xdp-context");
-  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
-  const char *app_id = xdp_app_info_get_id (app_info);
-  g_autoptr(GError) error = NULL;
-  const char *handle_token = NULL;
-  g_autofree char *handle = NULL;
-  g_autoptr(InstallMonitor) monitor = NULL;
-  g_autoptr(GSubprocess) subprocess = NULL;
-  g_autoptr(GPtrArray) args = NULL;
-  int i;
   size_t app_id_len = strlen (app_id);
-
-  if (xdp_app_info_is_host (app_info))
-    {
-      g_dbus_method_invocation_return_error (invocation,
-                                             XDG_DESKTOP_PORTAL_ERROR,
-                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
-                                             _("Only sandboxed applications can install extensions"));
-      return G_DBUS_METHOD_INVOCATION_HANDLED;
-    }
+  int i;
 
   for (i = 0; arg_extensions[i] != NULL; i++)
     {
@@ -230,9 +258,43 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
                                                  XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                                                  _("Extension ID %s does not start with app ID %s."),
                                                  ext, app_id);
-          return G_DBUS_METHOD_INVOCATION_HANDLED;
+          return FALSE;
         }
     }
+  return TRUE;
+}
+
+static gboolean
+start_flatpak_operation (XdpDbusFlatpakInstaller *object,
+                         GDBusMethodInvocation *invocation,
+                         const char * const * arg_extensions,
+                         GVariant *arg_options,
+                         const char * command)
+{
+  FlatpakPortal *portal = (FlatpakPortal *)object;
+  XdpContext *context = portal->context;
+  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
+  const char *app_id = xdp_app_info_get_id (app_info);
+  const char *sender = g_dbus_method_invocation_get_sender (invocation);
+  g_autoptr(GError) error = NULL;
+  const char *handle_token = NULL;
+  g_autofree char *handle = NULL;
+  g_autoptr(InstallMonitor) monitor = NULL;
+  g_autoptr(GSubprocess) subprocess = NULL;
+  g_autoptr(GPtrArray) args = NULL;
+  int i;
+
+  if (xdp_app_info_is_host (app_info))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             _("Only sandboxed applications can perform this operation"));
+      return TRUE;
+    }
+
+  if (!validate_extensions (invocation, app_id, arg_extensions))
+    return TRUE;
 
   g_variant_lookup (arg_options, "handle_token", "&s", &handle_token);
   if (handle_token)
@@ -243,7 +305,7 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
                                                  XDG_DESKTOP_PORTAL_ERROR,
                                                  XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
                                                  _("Invalid handle token: %s"), handle_token);
-          return G_DBUS_METHOD_INVOCATION_HANDLED;
+          return TRUE;
         }
     }
   else
@@ -252,13 +314,13 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
     }
 
   {
-    g_autofree char *sender = g_strdup (g_dbus_method_invocation_get_sender (invocation) + 1);
+    g_autofree char *sender_stripped = g_strdup (sender + 1);
     int j;
-    for (j = 0; sender[j] != '\0'; j++)
-      if (sender[j] == '.')
-        sender[j] = '_';
+    for (j = 0; sender_stripped[j] != '\0'; j++)
+      if (sender_stripped[j] == '.')
+        sender_stripped[j] = '_';
 
-    handle = g_strdup_printf ("/org/freedesktop/portal/FlatpakInstaller/install_monitor/%s/%s", sender, handle_token);
+    handle = g_strdup_printf ("/org/freedesktop/portal/FlatpakInstaller/install_monitor/%s/%s", sender_stripped, handle_token);
   }
 
   if (!xdp_context_claim_object_path (context, handle))
@@ -267,10 +329,10 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
                                              XDG_DESKTOP_PORTAL_ERROR,
                                              XDG_DESKTOP_PORTAL_ERROR_EXISTS,
                                              _("Handle already in use"));
-      return G_DBUS_METHOD_INVOCATION_HANDLED;
+      return TRUE;
     }
 
-  monitor = install_monitor_new (context, handle);
+  monitor = install_monitor_new (context, handle, sender);
 
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (monitor),
                                          xdp_context_get_connection (context),
@@ -279,17 +341,18 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
     {
       xdp_context_unclaim_object_path (context, handle);
       g_dbus_method_invocation_return_gerror (invocation, error);
-      return G_DBUS_METHOD_INVOCATION_HANDLED;
+      return TRUE;
     }
 
-  g_debug ("Installing extensions for %s: %s", app_id, handle);
+  g_debug ("Performing %s extensions for %s: %s", command, app_id, handle);
 
   args = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (args, g_strdup ("flatpak"));
-  g_ptr_array_add (args, g_strdup ("install"));
+  g_ptr_array_add (args, g_strdup (command));
   g_ptr_array_add (args, g_strdup ("--user"));
   g_ptr_array_add (args, g_strdup ("--noninteractive"));
   g_ptr_array_add (args, g_strdup ("-y"));
+  g_ptr_array_add (args, g_strdup ("--"));
 
   for (i = 0; arg_extensions[i] != NULL; i++)
     g_ptr_array_add (args, g_strdup (arg_extensions[i]));
@@ -302,7 +365,7 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
 
   if (!subprocess)
     {
-      g_warning ("Failed to start flatpak install: %s", error->message);
+      g_warning ("Failed to start flatpak %s: %s", command, error->message);
       emit_progress (monitor, 2, 0, "org.freedesktop.portal.FlatpakInstaller.Error.Failed", error->message);
     }
   else
@@ -310,11 +373,144 @@ handle_install_extensions (XdpDbusFlatpakInstaller        *object,
       emit_progress (monitor, 0, 0, NULL, NULL);
       g_subprocess_wait_async (subprocess,
                                monitor->cancellable,
-                               install_finished_cb,
+                               operation_finished_cb,
                                g_object_ref (monitor));
     }
 
-  xdp_dbus_flatpak_installer_complete_install_extensions (object, invocation, handle);
+  if (strcmp (command, "install") == 0)
+    xdp_dbus_flatpak_installer_complete_install_extensions (object, invocation, handle);
+  else if (strcmp (command, "uninstall") == 0)
+    xdp_dbus_flatpak_installer_complete_uninstall_extensions (object, invocation, handle);
+  else if (strcmp (command, "update") == 0)
+    xdp_dbus_flatpak_installer_complete_update_extensions (object, invocation, handle);
+
+  return TRUE;
+}
+
+static gboolean
+handle_install_extensions (XdpDbusFlatpakInstaller        *object,
+                           GDBusMethodInvocation *invocation,
+                           const char * const    *arg_extensions,
+                           GVariant              *arg_options)
+{
+  return start_flatpak_operation (object, invocation, arg_extensions, arg_options, "install");
+}
+
+static gboolean
+handle_uninstall_extensions (XdpDbusFlatpakInstaller        *object,
+                             GDBusMethodInvocation *invocation,
+                             const char * const    *arg_extensions,
+                             GVariant              *arg_options)
+{
+  return start_flatpak_operation (object, invocation, arg_extensions, arg_options, "uninstall");
+}
+
+static gboolean
+handle_update_extensions (XdpDbusFlatpakInstaller        *object,
+                          GDBusMethodInvocation *invocation,
+                          const char * const    *arg_extensions,
+                          GVariant              *arg_options)
+{
+  return start_flatpak_operation (object, invocation, arg_extensions, arg_options, "update");
+}
+
+typedef struct {
+  XdpDbusFlatpakInstaller *object;
+  GDBusMethodInvocation *invocation;
+  char *app_id;
+} ListExtensionsData;
+
+static void
+list_extensions_data_free (ListExtensionsData *data)
+{
+  g_clear_object (&data->object);
+  g_free (data->app_id);
+  g_free (data);
+}
+
+static void
+list_extensions_finished_cb (GObject      *source,
+                             GAsyncResult *result,
+                             gpointer      user_data)
+{
+  ListExtensionsData *data = user_data;
+  g_autoptr(GSubprocess) subprocess = G_SUBPROCESS (source);
+  g_autoptr(GError) error = NULL;
+  g_autofree char *stdout_buf = NULL;
+  g_autofree char *stderr_buf = NULL;
+  g_auto(GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("aa{sv}"));
+
+  if (!g_subprocess_communicate_utf8_finish (subprocess, result, &stdout_buf, &stderr_buf, &error))
+    {
+      g_dbus_method_invocation_return_gerror (data->invocation, error);
+      list_extensions_data_free (data);
+      return;
+    }
+
+  if (stdout_buf)
+    {
+      g_auto(GStrv) lines = g_strsplit (stdout_buf, "\n", -1);
+      int i;
+      size_t app_id_len = strlen (data->app_id);
+
+      for (i = 0; lines[i] != NULL; i++)
+        {
+          g_auto(GStrv) parts = g_strsplit (lines[i], "\t", 4);
+          if (g_strv_length (parts) >= 4)
+            {
+              const char *ext_id = parts[0];
+              if (g_str_has_prefix (ext_id, data->app_id) && ext_id[app_id_len] == '.')
+                {
+                  g_auto(GVariantBuilder) ext_builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_VARDICT);
+                  g_variant_builder_add (&ext_builder, "{sv}", "id", g_variant_new_string (parts[0]));
+                  g_variant_builder_add (&ext_builder, "{sv}", "name", g_variant_new_string (parts[1]));
+                  g_variant_builder_add (&ext_builder, "{sv}", "version", g_variant_new_string (parts[2]));
+                  g_variant_builder_add (&ext_builder, "{sv}", "summary", g_variant_new_string (parts[3]));
+                  g_variant_builder_add (&builder, "a{sv}", &ext_builder);
+                }
+            }
+        }
+    }
+
+  xdp_dbus_flatpak_installer_complete_list_extensions (data->object, data->invocation, g_variant_builder_end (&builder));
+  list_extensions_data_free (data);
+}
+
+static gboolean
+handle_list_extensions (XdpDbusFlatpakInstaller        *object,
+                        GDBusMethodInvocation *invocation,
+                        GVariant              *arg_options)
+{
+  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
+  const char *app_id = xdp_app_info_get_id (app_info);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GSubprocess) subprocess = NULL;
+  ListExtensionsData *data;
+
+  if (xdp_app_info_is_host (app_info))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             _("Only sandboxed applications can perform this operation"));
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  subprocess = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_PIPE,
+                                 &error,
+                                 "flatpak", "list", "--user", "--app", "--columns=application,name,version,summary", NULL);
+  if (!subprocess)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  data = g_new0 (ListExtensionsData, 1);
+  data->object = g_object_ref (object);
+  data->invocation = invocation;
+  data->app_id = g_strdup (app_id);
+
+  g_subprocess_communicate_utf8_async (subprocess, NULL, NULL, list_extensions_finished_cb, data);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
@@ -323,6 +519,9 @@ static void
 flatpak_portal_iface_init (XdpDbusFlatpakInstallerIface *iface)
 {
   iface->handle_install_extensions = handle_install_extensions;
+  iface->handle_uninstall_extensions = handle_uninstall_extensions;
+  iface->handle_update_extensions = handle_update_extensions;
+  iface->handle_list_extensions = handle_list_extensions;
 }
 
 void
@@ -331,7 +530,7 @@ init_flatpak (XdpContext *context)
   g_autoptr(FlatpakPortal) portal = NULL;
 
   portal = g_object_new (flatpak_portal_get_type (), NULL);
-  g_object_set_data (G_OBJECT (portal), "xdp-context", context);
+  portal->context = context;
 
   xdp_context_take_and_export_portal (context,
                                       G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&portal)),

--- a/src/flatpak.c
+++ b/src/flatpak.c
@@ -29,7 +29,6 @@
 #include "xdp-context.h"
 #include "xdp-dbus.h"
 #include "xdp-utils.h"
-#include "flatpak-instance.h"
 
 #include "flatpak.h"
 
@@ -38,12 +37,12 @@ typedef struct _FlatpakPortalClass FlatpakPortalClass;
 
 struct _FlatpakPortal
 {
-  XdpDbusFlatpakSkeleton parent_instance;
+  XdpDbusFlatpakInstallerSkeleton parent_instance;
 };
 
 struct _FlatpakPortalClass
 {
-  XdpDbusFlatpakSkeletonClass parent_class;
+  XdpDbusFlatpakInstallerSkeletonClass parent_class;
 };
 
 typedef struct _InstallMonitor InstallMonitor;
@@ -51,7 +50,7 @@ typedef struct _InstallMonitorClass InstallMonitorClass;
 
 struct _InstallMonitor
 {
-  XdpDbusFlatpakInstallMonitorSkeleton parent_instance;
+  XdpDbusFlatpakInstallerInstallMonitorSkeleton parent_instance;
   XdpContext *context;
   char *id;
   GCancellable *cancellable;
@@ -59,23 +58,23 @@ struct _InstallMonitor
 
 struct _InstallMonitorClass
 {
-  XdpDbusFlatpakInstallMonitorSkeletonClass parent_class;
+  XdpDbusFlatpakInstallerInstallMonitorSkeletonClass parent_class;
 };
 
 GType flatpak_portal_get_type (void) G_GNUC_CONST;
-static void flatpak_portal_iface_init (XdpDbusFlatpakIface *iface);
+static void flatpak_portal_iface_init (XdpDbusFlatpakInstallerIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (FlatpakPortal, flatpak_portal,
-                         XDP_DBUS_TYPE_FLATPAK_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_FLATPAK,
+                         XDP_DBUS_TYPE_FLATPAK_INSTALLER_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_FLATPAK_INSTALLER,
                                                 flatpak_portal_iface_init));
 
 GType install_monitor_get_type (void) G_GNUC_CONST;
-static void install_monitor_iface_init (XdpDbusFlatpakInstallMonitorIface *iface);
+static void install_monitor_iface_init (XdpDbusFlatpakInstallerInstallMonitorIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (InstallMonitor, install_monitor,
-                         XDP_DBUS_TYPE_FLATPAK_INSTALL_MONITOR_SKELETON,
-                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_FLATPAK_INSTALL_MONITOR,
+                         XDP_DBUS_TYPE_FLATPAK_INSTALLER_INSTALL_MONITOR_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_FLATPAK_INSTALLER_INSTALL_MONITOR,
                                                 install_monitor_iface_init));
 
 static void
@@ -105,7 +104,7 @@ install_monitor_class_init (InstallMonitorClass *klass)
 }
 
 static gboolean
-handle_close (XdpDbusFlatpakInstallMonitor *object,
+handle_close (XdpDbusFlatpakInstallerInstallMonitor *object,
               GDBusMethodInvocation        *invocation)
 {
   InstallMonitor *monitor = (InstallMonitor *)object;
@@ -116,13 +115,13 @@ handle_close (XdpDbusFlatpakInstallMonitor *object,
   xdp_context_unclaim_object_path (monitor->context, monitor->id);
   g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (monitor));
 
-  xdp_dbus_flatpak_install_monitor_complete_close (object, invocation);
+  xdp_dbus_flatpak_installer_install_monitor_complete_close (object, invocation);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static void
-install_monitor_iface_init (XdpDbusFlatpakInstallMonitorIface *iface)
+install_monitor_iface_init (XdpDbusFlatpakInstallerInstallMonitorIface *iface)
 {
   iface->handle_close = handle_close;
 }
@@ -143,7 +142,7 @@ install_monitor_new (XdpContext *context,
 static void
 flatpak_portal_init (FlatpakPortal *portal)
 {
-  xdp_dbus_flatpak_set_version (XDP_DBUS_FLATPAK (portal), 1);
+  xdp_dbus_flatpak_installer_set_version (XDP_DBUS_FLATPAK_INSTALLER (portal), 1);
 }
 
 static void
@@ -167,7 +166,7 @@ emit_progress (InstallMonitor *monitor,
   if (error_message)
     g_variant_builder_add (&builder, "{sv}", "error_message", g_variant_new_string (error_message));
 
-  xdp_dbus_flatpak_install_monitor_emit_progress (XDP_DBUS_FLATPAK_INSTALL_MONITOR (monitor),
+  xdp_dbus_flatpak_installer_install_monitor_emit_progress (XDP_DBUS_FLATPAK_INSTALLER_INSTALL_MONITOR (monitor),
                                                   g_variant_builder_end (&builder));
 }
 
@@ -185,7 +184,7 @@ install_finished_cb (GObject      *source,
         return;
 
       g_warning ("Flatpak install failed: %s", error->message);
-      emit_progress (monitor, 2, 0, "org.freedesktop.portal.Flatpak.Error.Failed", error->message);
+      emit_progress (monitor, 2, 0, "org.freedesktop.portal.FlatpakInstaller.Error.Failed", error->message);
     }
   else
     {
@@ -195,7 +194,7 @@ install_finished_cb (GObject      *source,
 }
 
 static gboolean
-handle_install_extensions (XdpDbusFlatpak        *object,
+handle_install_extensions (XdpDbusFlatpakInstaller        *object,
                            GDBusMethodInvocation *invocation,
                            const char * const    *arg_extensions,
                            GVariant              *arg_options)
@@ -259,7 +258,7 @@ handle_install_extensions (XdpDbusFlatpak        *object,
       if (sender[j] == '.')
         sender[j] = '_';
 
-    handle = g_strdup_printf ("/org/freedesktop/portal/Flatpak/install_monitor/%s/%s", sender, handle_token);
+    handle = g_strdup_printf ("/org/freedesktop/portal/FlatpakInstaller/install_monitor/%s/%s", sender, handle_token);
   }
 
   if (!xdp_context_claim_object_path (context, handle))
@@ -304,7 +303,7 @@ handle_install_extensions (XdpDbusFlatpak        *object,
   if (!subprocess)
     {
       g_warning ("Failed to start flatpak install: %s", error->message);
-      emit_progress (monitor, 2, 0, "org.freedesktop.portal.Flatpak.Error.Failed", error->message);
+      emit_progress (monitor, 2, 0, "org.freedesktop.portal.FlatpakInstaller.Error.Failed", error->message);
     }
   else
     {
@@ -315,13 +314,13 @@ handle_install_extensions (XdpDbusFlatpak        *object,
                                g_object_ref (monitor));
     }
 
-  xdp_dbus_flatpak_complete_install_extensions (object, invocation, handle);
+  xdp_dbus_flatpak_installer_complete_install_extensions (object, invocation, handle);
 
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static void
-flatpak_portal_iface_init (XdpDbusFlatpakIface *iface)
+flatpak_portal_iface_init (XdpDbusFlatpakInstallerIface *iface)
 {
   iface->handle_install_extensions = handle_install_extensions;
 }

--- a/src/flatpak.c
+++ b/src/flatpak.c
@@ -1,0 +1,340 @@
+/*
+ * Copyright © 2024 Red Hat, Inc
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jules Agent
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <glib/gi18n.h>
+
+#include "xdp-app-info.h"
+#include "xdp-context.h"
+#include "xdp-dbus.h"
+#include "xdp-utils.h"
+#include "flatpak-instance.h"
+
+#include "flatpak.h"
+
+typedef struct _FlatpakPortal FlatpakPortal;
+typedef struct _FlatpakPortalClass FlatpakPortalClass;
+
+struct _FlatpakPortal
+{
+  XdpDbusFlatpakSkeleton parent_instance;
+};
+
+struct _FlatpakPortalClass
+{
+  XdpDbusFlatpakSkeletonClass parent_class;
+};
+
+typedef struct _InstallMonitor InstallMonitor;
+typedef struct _InstallMonitorClass InstallMonitorClass;
+
+struct _InstallMonitor
+{
+  XdpDbusFlatpakInstallMonitorSkeleton parent_instance;
+  XdpContext *context;
+  char *id;
+  GCancellable *cancellable;
+};
+
+struct _InstallMonitorClass
+{
+  XdpDbusFlatpakInstallMonitorSkeletonClass parent_class;
+};
+
+GType flatpak_portal_get_type (void) G_GNUC_CONST;
+static void flatpak_portal_iface_init (XdpDbusFlatpakIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (FlatpakPortal, flatpak_portal,
+                         XDP_DBUS_TYPE_FLATPAK_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_FLATPAK,
+                                                flatpak_portal_iface_init));
+
+GType install_monitor_get_type (void) G_GNUC_CONST;
+static void install_monitor_iface_init (XdpDbusFlatpakInstallMonitorIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (InstallMonitor, install_monitor,
+                         XDP_DBUS_TYPE_FLATPAK_INSTALL_MONITOR_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_DBUS_TYPE_FLATPAK_INSTALL_MONITOR,
+                                                install_monitor_iface_init));
+
+static void
+install_monitor_init (InstallMonitor *monitor)
+{
+  monitor->cancellable = g_cancellable_new ();
+}
+
+static void
+install_monitor_finalize (GObject *object)
+{
+  InstallMonitor *monitor = (InstallMonitor *)object;
+
+  g_cancellable_cancel (monitor->cancellable);
+  g_clear_object (&monitor->cancellable);
+  g_free (monitor->id);
+
+  G_OBJECT_CLASS (install_monitor_parent_class)->finalize (object);
+}
+
+static void
+install_monitor_class_init (InstallMonitorClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = install_monitor_finalize;
+}
+
+static gboolean
+handle_close (XdpDbusFlatpakInstallMonitor *object,
+              GDBusMethodInvocation        *invocation)
+{
+  InstallMonitor *monitor = (InstallMonitor *)object;
+
+  g_debug ("Closing install monitor %s", monitor->id);
+
+  g_cancellable_cancel (monitor->cancellable);
+  xdp_context_unclaim_object_path (monitor->context, monitor->id);
+  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (monitor));
+
+  xdp_dbus_flatpak_install_monitor_complete_close (object, invocation);
+
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+static void
+install_monitor_iface_init (XdpDbusFlatpakInstallMonitorIface *iface)
+{
+  iface->handle_close = handle_close;
+}
+
+static InstallMonitor *
+install_monitor_new (XdpContext *context,
+                     const char *id)
+{
+  InstallMonitor *monitor;
+
+  monitor = g_object_new (install_monitor_get_type (), NULL);
+  monitor->context = context;
+  monitor->id = g_strdup (id);
+
+  return monitor;
+}
+
+static void
+flatpak_portal_init (FlatpakPortal *portal)
+{
+  xdp_dbus_flatpak_set_version (XDP_DBUS_FLATPAK (portal), 1);
+}
+
+static void
+flatpak_portal_class_init (FlatpakPortalClass *klass)
+{
+}
+
+static void
+emit_progress (InstallMonitor *monitor,
+               guint32         status,
+               guint32         progress,
+               const char     *error,
+               const char     *error_message)
+{
+  GVariantBuilder builder;
+  g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&builder, "{sv}", "status", g_variant_new_uint32 (status));
+  g_variant_builder_add (&builder, "{sv}", "progress", g_variant_new_uint32 (progress));
+  if (error)
+    g_variant_builder_add (&builder, "{sv}", "error", g_variant_new_string (error));
+  if (error_message)
+    g_variant_builder_add (&builder, "{sv}", "error_message", g_variant_new_string (error_message));
+
+  xdp_dbus_flatpak_install_monitor_emit_progress (XDP_DBUS_FLATPAK_INSTALL_MONITOR (monitor),
+                                                  g_variant_builder_end (&builder));
+}
+
+static void
+install_finished_cb (GObject      *source,
+                     GAsyncResult *result,
+                     gpointer      user_data)
+{
+  g_autoptr(InstallMonitor) monitor = user_data;
+  g_autoptr(GError) error = NULL;
+
+  if (!g_subprocess_wait_check_finish (G_SUBPROCESS (source), result, &error))
+    {
+      if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        return;
+
+      g_warning ("Flatpak install failed: %s", error->message);
+      emit_progress (monitor, 2, 0, "org.freedesktop.portal.Flatpak.Error.Failed", error->message);
+    }
+  else
+    {
+      g_debug ("Flatpak install finished successfully");
+      emit_progress (monitor, 1, 100, NULL, NULL);
+    }
+}
+
+static gboolean
+handle_install_extensions (XdpDbusFlatpak        *object,
+                           GDBusMethodInvocation *invocation,
+                           const char * const    *arg_extensions,
+                           GVariant              *arg_options)
+{
+  XdpContext *context = g_object_get_data (G_OBJECT (object), "xdp-context");
+  XdpAppInfo *app_info = xdp_invocation_get_app_info (invocation);
+  const char *app_id = xdp_app_info_get_id (app_info);
+  g_autoptr(GError) error = NULL;
+  const char *handle_token = NULL;
+  g_autofree char *handle = NULL;
+  g_autoptr(InstallMonitor) monitor = NULL;
+  g_autoptr(GSubprocess) subprocess = NULL;
+  g_autoptr(GPtrArray) args = NULL;
+  int i;
+  size_t app_id_len = strlen (app_id);
+
+  if (xdp_app_info_is_host (app_info))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_ALLOWED,
+                                             _("Only sandboxed applications can install extensions"));
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  for (i = 0; arg_extensions[i] != NULL; i++)
+    {
+      const char *ext = arg_extensions[i];
+      if (!g_str_has_prefix (ext, app_id) || ext[app_id_len] != '.')
+        {
+          g_dbus_method_invocation_return_error (invocation,
+                                                 XDG_DESKTOP_PORTAL_ERROR,
+                                                 XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                                                 _("Extension ID %s does not start with app ID %s."),
+                                                 ext, app_id);
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+    }
+
+  g_variant_lookup (arg_options, "handle_token", "&s", &handle_token);
+  if (handle_token)
+    {
+      if (!xdp_is_valid_token (handle_token))
+        {
+          g_dbus_method_invocation_return_error (invocation,
+                                                 XDG_DESKTOP_PORTAL_ERROR,
+                                                 XDG_DESKTOP_PORTAL_ERROR_INVALID_ARGUMENT,
+                                                 _("Invalid handle token: %s"), handle_token);
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+    }
+  else
+    {
+      handle_token = "t";
+    }
+
+  {
+    g_autofree char *sender = g_strdup (g_dbus_method_invocation_get_sender (invocation) + 1);
+    int j;
+    for (j = 0; sender[j] != '\0'; j++)
+      if (sender[j] == '.')
+        sender[j] = '_';
+
+    handle = g_strdup_printf ("/org/freedesktop/portal/Flatpak/install_monitor/%s/%s", sender, handle_token);
+  }
+
+  if (!xdp_context_claim_object_path (context, handle))
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_EXISTS,
+                                             _("Handle already in use"));
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  monitor = install_monitor_new (context, handle);
+
+  if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (monitor),
+                                         xdp_context_get_connection (context),
+                                         handle,
+                                         &error))
+    {
+      xdp_context_unclaim_object_path (context, handle);
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  g_debug ("Installing extensions for %s: %s", app_id, handle);
+
+  args = g_ptr_array_new_with_free_func (g_free);
+  g_ptr_array_add (args, g_strdup ("flatpak"));
+  g_ptr_array_add (args, g_strdup ("install"));
+  g_ptr_array_add (args, g_strdup ("--user"));
+  g_ptr_array_add (args, g_strdup ("--noninteractive"));
+  g_ptr_array_add (args, g_strdup ("-y"));
+
+  for (i = 0; arg_extensions[i] != NULL; i++)
+    g_ptr_array_add (args, g_strdup (arg_extensions[i]));
+
+  g_ptr_array_add (args, NULL);
+
+  subprocess = g_subprocess_newv ((const gchar * const *)args->pdata,
+                                   G_SUBPROCESS_FLAGS_NONE,
+                                   &error);
+
+  if (!subprocess)
+    {
+      g_warning ("Failed to start flatpak install: %s", error->message);
+      emit_progress (monitor, 2, 0, "org.freedesktop.portal.Flatpak.Error.Failed", error->message);
+    }
+  else
+    {
+      emit_progress (monitor, 0, 0, NULL, NULL);
+      g_subprocess_wait_async (subprocess,
+                               monitor->cancellable,
+                               install_finished_cb,
+                               g_object_ref (monitor));
+    }
+
+  xdp_dbus_flatpak_complete_install_extensions (object, invocation, handle);
+
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+static void
+flatpak_portal_iface_init (XdpDbusFlatpakIface *iface)
+{
+  iface->handle_install_extensions = handle_install_extensions;
+}
+
+void
+init_flatpak (XdpContext *context)
+{
+  g_autoptr(FlatpakPortal) portal = NULL;
+
+  portal = g_object_new (flatpak_portal_get_type (), NULL);
+  g_object_set_data (G_OBJECT (portal), "xdp-context", context);
+
+  xdp_context_take_and_export_portal (context,
+                                      G_DBUS_INTERFACE_SKELETON (g_steal_pointer (&portal)),
+                                      XDP_CONTEXT_EXPORT_FLAGS_NONE);
+}

--- a/src/flatpak.h
+++ b/src/flatpak.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2024 Red Hat, Inc
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jules Agent
+ */
+
+#pragma once
+
+#include "xdp-context.h"
+
+void init_flatpak (XdpContext *context);

--- a/src/meson.build
+++ b/src/meson.build
@@ -90,6 +90,7 @@ xdg_desktop_portal_sources = files(
   'dynamic-launcher.c',
   'email.c',
   'file-chooser.c',
+  'flatpak.c',
   'flatpak-instance.c',
   'gamemode.c',
   'global-shortcuts.c',

--- a/src/xdp-context.c
+++ b/src/xdp-context.c
@@ -35,6 +35,7 @@
 #include "dynamic-launcher.h"
 #include "email.h"
 #include "file-chooser.h"
+#include "flatpak.h"
 #include "gamemode.h"
 #include "global-shortcuts.h"
 #include "inhibit.h"
@@ -392,6 +393,7 @@ xdp_context_register (XdpContext       *context,
   init_realtime (context);
   init_settings (context);
   init_file_chooser (context);
+  init_flatpak (context);
   init_open_uri (context);
   init_print (context);
   init_notification (context);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -90,6 +90,7 @@ pytest_files = [
   'test_dynamiclauncher.py',
   'test_email.py',
   'test_filechooser.py',
+  'test_flatpak.py',
   'test_globalshortcuts.py',
   'test_inhibit.py',
   'test_inputcapture.py',

--- a/tests/test_flatpak.py
+++ b/tests/test_flatpak.py
@@ -21,14 +21,20 @@ def xdp_mocked_executables(xdp_app_info: xdp.AppInfo) -> list[xdp.ExecutableMock
 
     class FlatpakMock(xdp.ExecutableMock):
         def get_executable(self):
-            # Mock flatpak install to succeed
-            return b"""#!/usr/bin/env sh
-if [ "$1" = "install" ]; then
-    echo "Mocked flatpak install $@" >&2
+            # Mock flatpak commands
+            return f"""#!/usr/bin/env sh
+if [ "$1" = "install" ] || [ "$1" = "uninstall" ] || [ "$1" = "update" ]; then
+    echo "Mocked flatpak $1 $@" >&2
+    exit 0
+fi
+if [ "$1" = "list" ]; then
+    echo "{xdp_app_info.app_id}.Extension1\tExtension One\t1.0\tA first extension"
+    echo "{xdp_app_info.app_id}.Extension2\tExtension Two\t2.1\tA second extension"
+    echo "org.other.App.Extension\tOther Extension\t0.1\tShould be filtered"
     exit 0
 fi
 exit 1
-"""
+""".encode("utf-8")
 
     return [
         FlatpakMock(
@@ -42,14 +48,10 @@ class TestFlatpak:
     def test_version(self, portals, dbus_con):
         xdp.check_version(dbus_con, "FlatpakInstaller", 1)
 
-    def test_install_extensions(self, portals, dbus_con, xdp_app_info):
-        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
-            pytest.skip("This test requires a Flatpak app info")
-
+    def _test_extension_op(self, method, dbus_con, app_id):
         flatpak_intf = xdp.get_portal_iface(dbus_con, "FlatpakInstaller")
-        app_id = xdp_app_info.app_id
         extensions = [f"{app_id}.Extension1", f"{app_id}.Extension2"]
-        options = {"handle_token": "test_token"}
+        options = {"handle_token": f"test_token_{method}"}
 
         progress_info = []
 
@@ -60,10 +62,10 @@ class TestFlatpak:
 
         loop = GLib.MainLoop()
 
-        handle = flatpak_intf.InstallExtensions(extensions, options)
+        handle = getattr(flatpak_intf, method)(extensions, options)
         assert (
             handle
-            == f"/org/freedesktop/portal/FlatpakInstaller/install_monitor/{dbus_con.get_unique_name().lstrip(':').replace('.', '_')}/test_token"
+            == f"/org/freedesktop/portal/FlatpakInstaller/install_monitor/{dbus_con.get_unique_name().lstrip(':').replace('.', '_')}/test_token_{method}"
         )
 
         monitor_obj = dbus_con.get_object("org.freedesktop.portal.Desktop", handle)
@@ -78,11 +80,38 @@ class TestFlatpak:
         loop.run()
 
         assert len(progress_info) >= 1
-        # We expect at least the "Done" signal, and possibly a "Running" signal before it.
         assert progress_info[-1]["status"] == 1  # Done
         assert progress_info[-1]["progress"] == 100
 
         monitor_intf.Close()
+
+    def test_install_extensions(self, portals, dbus_con, xdp_app_info):
+        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+            pytest.skip("This test requires a Flatpak app info")
+        self._test_extension_op("InstallExtensions", dbus_con, xdp_app_info.app_id)
+
+    def test_uninstall_extensions(self, portals, dbus_con, xdp_app_info):
+        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+            pytest.skip("This test requires a Flatpak app info")
+        self._test_extension_op("UninstallExtensions", dbus_con, xdp_app_info.app_id)
+
+    def test_update_extensions(self, portals, dbus_con, xdp_app_info):
+        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+            pytest.skip("This test requires a Flatpak app info")
+        self._test_extension_op("UpdateExtensions", dbus_con, xdp_app_info.app_id)
+
+    def test_list_extensions(self, portals, dbus_con, xdp_app_info):
+        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+            pytest.skip("This test requires a Flatpak app info")
+
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "FlatpakInstaller")
+        extensions = flatpak_intf.ListExtensions({})
+
+        assert len(extensions) == 2
+        assert extensions[0]["id"] == f"{xdp_app_info.app_id}.Extension1"
+        assert extensions[0]["name"] == "Extension One"
+        assert extensions[1]["id"] == f"{xdp_app_info.app_id}.Extension2"
+        assert extensions[1]["summary"] == "A second extension"
 
     def test_install_extensions_invalid_id(self, portals, dbus_con, xdp_app_info):
         if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
@@ -112,7 +141,6 @@ class TestFlatpak:
         )
 
     def test_install_extensions_host_forbidden(self, portals, dbus_con):
-        # The xdp_app_info fixture will iterate, but we can also use it as host
         flatpak_intf = xdp.get_portal_iface(dbus_con, "FlatpakInstaller")
 
         with pytest.raises(dbus.exceptions.DBusException) as excinfo:

--- a/tests/test_flatpak.py
+++ b/tests/test_flatpak.py
@@ -118,4 +118,6 @@ class TestFlatpak:
         with pytest.raises(dbus.exceptions.DBusException) as excinfo:
             flatpak_intf.InstallExtensions(["some.extension"], {})
 
-        assert excinfo.value.get_dbus_name() == "org.freedesktop.portal.Error.NotAllowed"
+        assert (
+            excinfo.value.get_dbus_name() == "org.freedesktop.portal.Error.NotAllowed"
+        )

--- a/tests/test_flatpak.py
+++ b/tests/test_flatpak.py
@@ -7,8 +7,6 @@ import tests.xdp_utils as xdp
 import dbus
 import pytest
 from gi.repository import GLib
-import os
-from pathlib import Path
 
 
 @pytest.fixture
@@ -42,13 +40,13 @@ exit 1
 
 class TestFlatpak:
     def test_version(self, portals, dbus_con):
-        xdp.check_version(dbus_con, "Flatpak", 1)
+        xdp.check_version(dbus_con, "FlatpakInstaller", 1)
 
     def test_install_extensions(self, portals, dbus_con, xdp_app_info):
         if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
             pytest.skip("This test requires a Flatpak app info")
 
-        flatpak_intf = xdp.get_portal_iface(dbus_con, "Flatpak")
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "FlatpakInstaller")
         app_id = xdp_app_info.app_id
         extensions = [f"{app_id}.Extension1", f"{app_id}.Extension2"]
         options = {"handle_token": "test_token"}
@@ -65,12 +63,12 @@ class TestFlatpak:
         handle = flatpak_intf.InstallExtensions(extensions, options)
         assert (
             handle
-            == f"/org/freedesktop/portal/Flatpak/install_monitor/{dbus_con.get_unique_name().lstrip(':').replace('.', '_')}/test_token"
+            == f"/org/freedesktop/portal/FlatpakInstaller/install_monitor/{dbus_con.get_unique_name().lstrip(':').replace('.', '_')}/test_token"
         )
 
         monitor_obj = dbus_con.get_object("org.freedesktop.portal.Desktop", handle)
         monitor_intf = dbus.Interface(
-            monitor_obj, "org.freedesktop.portal.Flatpak.InstallMonitor"
+            monitor_obj, "org.freedesktop.portal.FlatpakInstaller.InstallMonitor"
         )
         monitor_intf.connect_to_signal("Progress", on_progress)
 
@@ -90,10 +88,10 @@ class TestFlatpak:
         if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
             pytest.skip("This test requires a Flatpak app info")
 
-        flatpak_intf = xdp.get_portal_iface(dbus_con, "Flatpak")
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "FlatpakInstaller")
         # Matches prefix but not followed by dot
         extensions = [f"{xdp_app_info.app_id}Suffix"]
-        options = {}
+        options: dict[str, str] = {}
 
         with pytest.raises(dbus.exceptions.DBusException) as excinfo:
             flatpak_intf.InstallExtensions(extensions, options)
@@ -115,7 +113,7 @@ class TestFlatpak:
 
     def test_install_extensions_host_forbidden(self, portals, dbus_con):
         # The xdp_app_info fixture will iterate, but we can also use it as host
-        flatpak_intf = xdp.get_portal_iface(dbus_con, "Flatpak")
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "FlatpakInstaller")
 
         with pytest.raises(dbus.exceptions.DBusException) as excinfo:
             flatpak_intf.InstallExtensions(["some.extension"], {})

--- a/tests/test_flatpak.py
+++ b/tests/test_flatpak.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This file is formatted with Python Black
+
+import tests.xdp_utils as xdp
+
+import dbus
+import pytest
+from gi.repository import GLib
+import os
+from pathlib import Path
+
+
+@pytest.fixture
+def required_templates():
+    return {}
+
+
+@pytest.fixture
+def xdp_mocked_executables(xdp_app_info: xdp.AppInfo) -> list[xdp.ExecutableMock]:
+    if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+        return []
+
+    class FlatpakMock(xdp.ExecutableMock):
+        def get_executable(self):
+            # Mock flatpak install to succeed
+            return b"""#!/usr/bin/env sh
+if [ "$1" = "install" ]; then
+    echo "Mocked flatpak install $@" >&2
+    exit 0
+fi
+exit 1
+"""
+
+    return [
+        FlatpakMock(
+            executable="flatpak",
+            access_mode=xdp.FileAccessMode.HIDDEN,
+        )
+    ]
+
+
+class TestFlatpak:
+    def test_version(self, portals, dbus_con):
+        xdp.check_version(dbus_con, "Flatpak", 1)
+
+    def test_install_extensions(self, portals, dbus_con, xdp_app_info):
+        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+            pytest.skip("This test requires a Flatpak app info")
+
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "Flatpak")
+        app_id = xdp_app_info.app_id
+        extensions = [f"{app_id}.Extension1", f"{app_id}.Extension2"]
+        options = {"handle_token": "test_token"}
+
+        progress_info = []
+
+        def on_progress(info):
+            progress_info.append(info)
+            if info.get("status") != 0:  # Not Running
+                loop.quit()
+
+        loop = GLib.MainLoop()
+
+        handle = flatpak_intf.InstallExtensions(extensions, options)
+        assert (
+            handle
+            == f"/org/freedesktop/portal/Flatpak/install_monitor/{dbus_con.get_unique_name().lstrip(':').replace('.', '_')}/test_token"
+        )
+
+        monitor_obj = dbus_con.get_object("org.freedesktop.portal.Desktop", handle)
+        monitor_intf = dbus.Interface(
+            monitor_obj, "org.freedesktop.portal.Flatpak.InstallMonitor"
+        )
+        monitor_intf.connect_to_signal("Progress", on_progress)
+
+        # In the real implementation, the subprocess runs asynchronously.
+        # We wait for the finished status.
+        GLib.timeout_add(2000, loop.quit)
+        loop.run()
+
+        assert len(progress_info) >= 1
+        # We expect at least the "Done" signal, and possibly a "Running" signal before it.
+        assert progress_info[-1]["status"] == 1  # Done
+        assert progress_info[-1]["progress"] == 100
+
+        monitor_intf.Close()
+
+    def test_install_extensions_invalid_id(self, portals, dbus_con, xdp_app_info):
+        if xdp_app_info.kind != xdp.AppInfoKind.FLATPAK:
+            pytest.skip("This test requires a Flatpak app info")
+
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "Flatpak")
+        # Matches prefix but not followed by dot
+        extensions = [f"{xdp_app_info.app_id}Suffix"]
+        options = {}
+
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            flatpak_intf.InstallExtensions(extensions, options)
+
+        assert (
+            excinfo.value.get_dbus_name()
+            == "org.freedesktop.portal.Error.InvalidArgument"
+        )
+
+        # Does not match prefix at all
+        extensions = ["com.other.App.Extension"]
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            flatpak_intf.InstallExtensions(extensions, options)
+
+        assert (
+            excinfo.value.get_dbus_name()
+            == "org.freedesktop.portal.Error.InvalidArgument"
+        )
+
+    def test_install_extensions_host_forbidden(self, portals, dbus_con):
+        # The xdp_app_info fixture will iterate, but we can also use it as host
+        flatpak_intf = xdp.get_portal_iface(dbus_con, "Flatpak")
+
+        with pytest.raises(dbus.exceptions.DBusException) as excinfo:
+            flatpak_intf.InstallExtensions(["some.extension"], {})
+
+        assert excinfo.value.get_dbus_name() == "org.freedesktop.portal.Error.NotAllowed"


### PR DESCRIPTION
I have implemented the requested Flatpak extension installation support in `xdg-desktop-portal`. 

Key features:
- **New Portal Interface**: Added `org.freedesktop.portal.Flatpak` with the `InstallExtensions` method.
- **Security & Validation**: The portal strictly verifies that any extension being installed starts with the calling application's ID followed by a dot (e.g., `org.example.App.Plugin` for app `org.example.App`).
- **Automatic Installation**: Installations are performed non-interactively using `flatpak install --user --noninteractive -y`, as requested.
- **Progress Tracking**: A new `InstallMonitor` interface is returned, allowing apps to monitor the installation status via `Progress` signals (Running, Done, Failed).
- **Robustness**: The implementation uses asynchronous subprocess management and handles cancellation when the monitor is closed.
- **Testing**: Added a new Python test suite in `tests/test_flatpak.py` that mocks the `flatpak` binary to verify correct behavior and validation logic.

This implementation provides a secure and automated way for applications like OBS or editors to manage their own plugins/extensions within the Flatpak ecosystem.

---
*PR created automatically by Jules for task [15555506978764513012](https://jules.google.com/task/15555506978764513012) started by @razzeee*